### PR TITLE
Non existing subdomain error

### DIFF
--- a/app/controllers/users/base_controller.rb
+++ b/app/controllers/users/base_controller.rb
@@ -4,6 +4,7 @@ module Users
 
     before_action :authenticate_user!
     before_action :authorize_resource!
+    before_action :current_author
 
     protect_from_forgery with: :exception
 
@@ -14,7 +15,11 @@ module Users
     helper_method :current_author
 
     def current_author
-      @current_author ||= User.find_by(username: request.subdomain).decorate
+      @current_author ||= User.find_by!(username: request.subdomain).decorate
+    rescue ActiveRecord::RecordNotFound
+      redirect_to root_url(subdomain: "www"), notice: t(
+        "flash.no_such_user", user: request.subdomain
+      )
     end
   end
 end

--- a/config/locales/flash/en.yml
+++ b/config/locales/flash/en.yml
@@ -19,3 +19,4 @@ en:
       destroy:
         notice: "%{resource_name} was successfully destroyed."
         alert: "%{resource_name} could not be destroyed."
+    no_such_user: "There is no user named %{user}"

--- a/config/locales/flash/ru.yml
+++ b/config/locales/flash/ru.yml
@@ -19,3 +19,4 @@ ru:
       destroy:
         notice: "%{resource_name} успешно удалён."
         alert: "%{resource_name} не может быть удалён."
+    no_such_user: "Пользователя с именем %{user} не существует"


### PR DESCRIPTION
# Summary

When user visits some-user.md-notes.tech and some-user doesn't exist, it redirects to www.md-notes.tech with error message

Resolves #47  th issue.

## Steps performed

To do:

- Strictly find current_author
- When error happens, redirect user
- Run current_author method in advance
